### PR TITLE
Add testing status annotations

### DIFF
--- a/utils/src/main/java/io/github/frc5024/lib5k/utils/ColorUtils.java
+++ b/utils/src/main/java/io/github/frc5024/lib5k/utils/ColorUtils.java
@@ -1,7 +1,9 @@
 package io.github.frc5024.lib5k.utils;
 
 import edu.wpi.first.wpilibj.util.Color;
+import io.github.frc5024.lib5k.utils.annotations.FieldTested;
 
+@FieldTested(year=2020)
 public class ColorUtils {
 
 

--- a/utils/src/main/java/io/github/frc5024/lib5k/utils/InputUtils.java
+++ b/utils/src/main/java/io/github/frc5024/lib5k/utils/InputUtils.java
@@ -1,8 +1,11 @@
 package io.github.frc5024.lib5k.utils;
 
+import io.github.frc5024.lib5k.utils.annotations.FieldTested;
+
 /**
  * Utils for working with drive inputs
  */
+@FieldTested(year=2020)
 public class InputUtils {
 
     /**

--- a/utils/src/main/java/io/github/frc5024/lib5k/utils/ObjectCounter.java
+++ b/utils/src/main/java/io/github/frc5024/lib5k/utils/ObjectCounter.java
@@ -1,9 +1,11 @@
 package io.github.frc5024.lib5k.utils;
 
+import io.github.frc5024.lib5k.utils.annotations.FieldTested;
 
 /**
  * A helper for counting the number of an object that exists
  */
+@FieldTested(year=2020)
 public class ObjectCounter {
 
     private int count;

--- a/utils/src/main/java/io/github/frc5024/lib5k/utils/RobotMath.java
+++ b/utils/src/main/java/io/github/frc5024/lib5k/utils/RobotMath.java
@@ -3,7 +3,7 @@ package io.github.frc5024.lib5k.utils;
 import java.util.HashMap;
 
 import edu.wpi.first.wpiutil.CircularBuffer;
-
+import io.github.frc5024.lib5k.utils.annotations.FieldTested;
 import edu.wpi.first.wpilibj.geometry.Pose2d;
 import edu.wpi.first.wpilibj.geometry.Translation2d;
 
@@ -13,6 +13,7 @@ import ca.retrylife.ewmath.MathUtils;
 /**
  * RobotMath is an extension of MathUtils, with some overloads for robot-specific datatypes (the ewmath library is designed for general use, so excludes these functions)
  */
+@FieldTested(year=2019)
 public class RobotMath extends MathUtils{
 
     public static void main(String[] args) {

--- a/utils/src/main/java/io/github/frc5024/lib5k/utils/annotations/FieldTested.java
+++ b/utils/src/main/java/io/github/frc5024/lib5k/utils/annotations/FieldTested.java
@@ -1,8 +1,11 @@
 package io.github.frc5024.lib5k.utils.annotations;
 
+import java.lang.annotation.Documented;
+
 /**
  * Indicates that a class or method was successfully used by a team on an FRC field (on or off season)
  */
+@Documented
 public @interface FieldTested {
 
     /**

--- a/utils/src/main/java/io/github/frc5024/lib5k/utils/annotations/FieldTested.java
+++ b/utils/src/main/java/io/github/frc5024/lib5k/utils/annotations/FieldTested.java
@@ -1,0 +1,17 @@
+package io.github.frc5024.lib5k.utils.annotations;
+
+/**
+ * Indicates that a class or method was successfully used by a team on an FRC field (on or off season)
+ */
+public @interface FieldTested {
+
+    /**
+     * The team that tested this component
+     */
+    int team() default 5024;
+
+    /**
+     * The year this component was tested
+     */
+    int year();
+}

--- a/utils/src/main/java/io/github/frc5024/lib5k/utils/annotations/Tested.java
+++ b/utils/src/main/java/io/github/frc5024/lib5k/utils/annotations/Tested.java
@@ -1,0 +1,18 @@
+package io.github.frc5024.lib5k.utils.annotations;
+
+/**
+ * Indicates that a class or method was successfully used by a team on a robot
+ */
+public @interface Tested {
+
+    /**
+     * The team that tested this component
+     */
+    int team() default 5024;
+
+    /**
+     * A note about testing
+     */
+    String note() default "";
+    
+}

--- a/utils/src/main/java/io/github/frc5024/lib5k/utils/annotations/Tested.java
+++ b/utils/src/main/java/io/github/frc5024/lib5k/utils/annotations/Tested.java
@@ -1,8 +1,11 @@
 package io.github.frc5024.lib5k.utils.annotations;
 
+import java.lang.annotation.Documented;
+
 /**
  * Indicates that a class or method was successfully used by a team on a robot
  */
+@Documented
 public @interface Tested {
 
     /**

--- a/utils/src/main/java/io/github/frc5024/lib5k/utils/annotations/TestedInSimulation.java
+++ b/utils/src/main/java/io/github/frc5024/lib5k/utils/annotations/TestedInSimulation.java
@@ -1,8 +1,11 @@
 package io.github.frc5024.lib5k.utils.annotations;
 
+import java.lang.annotation.Documented;
+
 /**
  * Indicates that a class or method was successfully tested in a simulated environment
  */
+@Documented
 public @interface TestedInSimulation {
     
 }

--- a/utils/src/main/java/io/github/frc5024/lib5k/utils/annotations/TestedInSimulation.java
+++ b/utils/src/main/java/io/github/frc5024/lib5k/utils/annotations/TestedInSimulation.java
@@ -1,0 +1,8 @@
+package io.github.frc5024.lib5k.utils.annotations;
+
+/**
+ * Indicates that a class or method was successfully tested in a simulated environment
+ */
+public @interface TestedInSimulation {
+    
+}

--- a/utils/src/main/java/io/github/frc5024/lib5k/utils/annotations/Untested.java
+++ b/utils/src/main/java/io/github/frc5024/lib5k/utils/annotations/Untested.java
@@ -1,8 +1,11 @@
 package io.github.frc5024.lib5k.utils.annotations;
 
+import java.lang.annotation.Documented;
+
 /**
  * Indicates that a class or method has not been tested
  */
+@Documented
 public @interface Untested {
     
 }

--- a/utils/src/main/java/io/github/frc5024/lib5k/utils/annotations/Untested.java
+++ b/utils/src/main/java/io/github/frc5024/lib5k/utils/annotations/Untested.java
@@ -1,0 +1,8 @@
+package io.github.frc5024.lib5k.utils.annotations;
+
+/**
+ * Indicates that a class or method has not been tested
+ */
+public @interface Untested {
+    
+}


### PR DESCRIPTION
This PR adds annotations that we can use to tag classes. These are to keep track of what has been tested, and where.

For example,  if we write a class, then test it on a practice field, we can add the `@Tested` annotation