### PR TITLE
Cut compile time in half

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
         {
             "label": "build",
             "type": "shell",
-            "command": "./gradlew build",
+            "command": "./gradlew build --scan",
             "problemMatcher": [
                 "$msCompile"
             ],

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 org.gradle.parallel=true
+org.gradle.daemon=true

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,6 +9,7 @@
 
 rootProject.name = 'lib5k'
 
+
 // Bundle build script
 include ":bundle"
 


### PR DESCRIPTION
This PR enabled Gradle's parallel builds. This cuts compile time in half on my laptop.

Here are my build reports [before](https://scans.gradle.com/s/o2fhxquyx27zi) and [after](https://scans.gradle.com/s/j6ino3jr4ios4) implementing this PR.

This should also speed up CI