### PR TITLE
Update PurePursuit Paths to generate graphs of themselves

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ task document(type: Javadoc, description: 'Generate javadocs from all child proj
   options.setStylesheetFile(file("javadoc.css"))
   options.addBooleanOption('-no-module-directories', true)
 	options.author true
-	options.links 'http://docs.spring.io/spring/docs/4.3.x/javadoc-api/', 'http://docs.oracle.com/javase/8/docs/api/', 'http://docs.spring.io/spring-ws/docs/2.3.0.RELEASE/api/', 'http://docs.spring.io/spring-security/site/docs/4.0.4.RELEASE/apidocs/', 'https://first.wpi.edu/FRC/roborio/release/docs/java/', 'https://www.revrobotics.com/content/sw/max/sw-docs/java/', 'https://www.kauailabs.com/public_files/navx-mxp/apidocs/java/'
+	options.links 'http://docs.spring.io/spring/docs/4.3.x/javadoc-api/', 'http://docs.oracle.com/javase/8/docs/api/', 'http://docs.spring.io/spring-ws/docs/2.3.0.RELEASE/api/', 'http://docs.spring.io/spring-security/site/docs/4.0.4.RELEASE/apidocs/', 'https://first.wpi.edu/FRC/roborio/release/docs/java/', 'https://www.revrobotics.com/content/sw/max/sw-docs/java/', 'https://www.kauailabs.com/public_files/navx-mxp/apidocs/java/', 'https://knowm.org/javadocs/xchart/'
 	options.addStringOption 'Xdoclint:none', '-quiet'
     println "Building recursive JavaDoc"
 

--- a/purepursuit/build.gradle
+++ b/purepursuit/build.gradle
@@ -29,6 +29,9 @@ dependencies {
     // Math utils
     implementation 'com.github.ewpratten:ewmath:master-SNAPSHOT'
 
+    // Xchart
+    compile group: 'org.knowm.xchart', name: 'xchart', version: '3.2.2'
+
 
 }
 

--- a/purepursuit/src/main/java/io/github/frc5024/purepursuit/pathgen/Path.java
+++ b/purepursuit/src/main/java/io/github/frc5024/purepursuit/pathgen/Path.java
@@ -6,6 +6,12 @@ import java.util.Arrays;
 import edu.wpi.first.wpilibj.geometry.Translation2d;
 import edu.wpi.first.wpilibj.util.Units;
 
+import org.knowm.xchart.XYChart;
+import org.knowm.xchart.XYChartBuilder;
+import org.knowm.xchart.QuickChart;
+import org.knowm.xchart.XYSeries.XYSeriesRenderStyle;
+import org.knowm.xchart.style.Styler.LegendPosition;
+
 /**
  * A "Path" is a list of closely spaces points in space for a robot to follow.
  * The default Path class will generate paths with any number of waypoints, and
@@ -15,6 +21,7 @@ public class Path {
 
     // Path points
     protected ArrayList<Translation2d> points;
+    private Translation2d[] waypoints;
 
     /**
      * Create a motion path from points
@@ -33,6 +40,7 @@ public class Path {
      */
     public Path(double spacing, Translation2d... waypoints) {
         this.points = new ArrayList<>();
+        this.waypoints = waypoints;
 
         // Fill in extra points
         int i = 0;
@@ -62,6 +70,10 @@ public class Path {
                 // Create a new vector for this magnitude
                 Translation2d innerPoint = new Translation2d(normal.getX() * magnitude, normal.getY() * magnitude);
 
+                // Add the point to it's "base" point
+                innerPoint = innerPoint.plus(startTrans);
+                
+
                 // Add this vector to the list
                 this.points.add(innerPoint);
             }
@@ -85,6 +97,53 @@ public class Path {
     @Override
     public String toString() {
         return String.format("<Path: %s>", Arrays.deepToString(getPoses()));
+    }
+
+    /**
+     * Get a chart showing every generated path point in 2D space. Can be written to disk for debugging and demos.
+     * 
+     * @return Path visualization
+     */
+    public XYChart getPathVisualization() {
+
+        // Create X and Y datasets for points
+        double[] xData = new double[this.points.size()];
+        double[] yData = new double[this.points.size()];
+
+        // Save each point as an X and a Y
+        int i = 0;
+        for (Translation2d point : this.points) {
+            xData[i] = point.getX();
+            yData[i] = point.getY();
+            i++;
+        }
+
+        // Create X and Y datasets for waypoints
+        double[] wxData = new double[this.waypoints.length];
+        double[] wyData = new double[this.waypoints.length];
+
+        // Save each point as an X and a Y
+        i = 0;
+        for (Translation2d point : this.waypoints) {
+            wxData[i] = point.getX();
+            wyData[i] = point.getY();
+            i++;
+        }
+
+        // Build as a chart
+        // XYChart chart = QuickChart.getChart("Generated Path", "X (meters)", "Y (meters)", "path", xData, yData);
+        XYChart chart = new XYChartBuilder().width(800).height(600).build();
+
+        // Add data
+        chart.addSeries("Generated Path", xData, yData);
+        chart.addSeries("Waypoints", wxData, wyData);
+
+        // Configure chart styling
+        chart.getStyler().setDefaultSeriesRenderStyle(XYSeriesRenderStyle.Scatter);
+        chart.getStyler().setLegendPosition(LegendPosition.OutsideE);
+        chart.getStyler().setMarkerSize(8);
+        
+        return chart;
     }
 
 }

--- a/purepursuit/src/main/java/io/github/frc5024/purepursuit/pathgen/SmoothPath.java
+++ b/purepursuit/src/main/java/io/github/frc5024/purepursuit/pathgen/SmoothPath.java
@@ -17,7 +17,7 @@ public class SmoothPath extends Path {
      * @param tolerance How much the path is allowed to change
      * @param waypoints Path waypoints to follow
      */
-    public SmoothPath(double weight, double smoothing, double tolerance, Translation2d waypoints) {
+    public SmoothPath(double weight, double smoothing, double tolerance, Translation2d... waypoints) {
         this(Units.inchesToMeters(6.0), weight, smoothing, tolerance, waypoints);
     }
 
@@ -30,7 +30,7 @@ public class SmoothPath extends Path {
      * @param tolerance How much the path is allowed to change
      * @param waypoints Path waypoints to follow
      */
-    public SmoothPath(double spacing, double weight, double smoothing, double tolerance, Translation2d waypoints) {
+    public SmoothPath(double spacing, double weight, double smoothing, double tolerance, Translation2d... waypoints) {
 
         // Generate a linear path
         super(spacing, waypoints);

--- a/purepursuit/src/test/java/io/github/frc5024/purepursuit/pathgen/PathVizTest.java
+++ b/purepursuit/src/test/java/io/github/frc5024/purepursuit/pathgen/PathVizTest.java
@@ -1,0 +1,47 @@
+package io.github.frc5024.purepursuit.pathgen;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import edu.wpi.first.wpilibj.geometry.Translation2d;
+
+import org.knowm.xchart.XYChart;
+import org.knowm.xchart.BitmapEncoder;
+import org.knowm.xchart.BitmapEncoder.BitmapFormat;
+
+public class PathVizTest {
+
+    @Test
+    public void testFourPointPathViz() throws IOException {
+
+        // Create a path
+        Path path = new Path(new Translation2d(0.0, 0.0), new Translation2d(1.0, 3.0), new Translation2d(2.0, 2.0),
+                new Translation2d(3.0, 3.0));
+
+        // Get chart
+        XYChart chart = path.getPathVisualization();
+
+        // Save the chart visualization
+        BitmapEncoder.saveBitmap(chart, "./build/tmp/PurePursuit_UnitTest_FourPointPath", BitmapFormat.PNG);
+        System.out.println("Test result PNG generated to ./build/tmp/PurePursuit_UnitTest_FourPointPath.png");
+
+    }
+
+    @Test
+    public void testSmoothFourPointPathViz() throws IOException {
+
+        // Create a path
+        Path path = new SmoothPath(0.5, 0.5, 0.5, new Translation2d(0.0, 0.0), new Translation2d(1.0, 3.0),
+                new Translation2d(2.0, 2.0), new Translation2d(3.0, 3.0));
+
+        // Get chart
+        XYChart chart = path.getPathVisualization();
+
+        // Save the chart visualization
+        BitmapEncoder.saveBitmap(chart, "./build/tmp/PurePursuit_UnitTest_SmoothFourPointPath", BitmapFormat.PNG);
+        System.out.println("Test result PNG generated to ./build/tmp/PurePursuit_UnitTest_SmoothFourPointPath.png");
+
+    }
+
+}


### PR DESCRIPTION
This PR introduces [XChart](https://knowm.org/open-source/xchart/) support to Lib5K. Specifically letting anyone export any `Path` as an X/Y plot of it's points and waypoints. These plots can be saved as images for debugging.

( This can eventually be combined with #32 )

## Examples
Here are some example graphs generated by unit tests

### 3 waypoints, no smoothing

![3 waypoints, no smoothing](https://i.imgur.com/Yz9V4Cj.png)

### 3 waypoints, smoothed with `SmoothPath`

The smoothing parameters are:

| Setting | Value |
| -- | -- |
| Weight | `0.5` |
| Smoothing | `0.5` |
| Tolerance | `0.5` |

![3 waypoints, smoothed with SmoothPath](https://i.imgur.com/15JkmEm.png)

## Unit tests
During the PurePursuit unit tests, graphs are automatically generated to `./purepursuit/build/tmp/<test_name>.png`

## Bug fixes
This PR also fixes a bug with path segment alignment that was causing random paths to be generated sometimes