### PR TITLE
Automatically shorten package names

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-    "java.configuration.updateBuildConfiguration": "interactive"
+    "java.configuration.updateBuildConfiguration": "interactive",
+    "cSpell.words": [
+        "seperator"
+    ]
 }

--- a/logging/src/test/java/io/github/frc5024/lib5k/logging/RobotLoggerTest.java
+++ b/logging/src/test/java/io/github/frc5024/lib5k/logging/RobotLoggerTest.java
@@ -1,0 +1,23 @@
+package io.github.frc5024.lib5k.logging;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class RobotLoggerTest {
+
+    @Test
+    public void testPackageNameConstruction() {
+
+        // Get a stack trace to this method
+        StackTraceElement thisMethod = Thread.currentThread().getStackTrace()[1];
+
+        // Get the friendly package string
+        String friendlyPackageName = RobotLogger.getPackageName(thisMethod);
+
+        // Check if correct
+        assertEquals("Package name", "io...logging.RobotLoggerTest::testPackageNameConstruction()", friendlyPackageName);
+
+    }
+
+}


### PR DESCRIPTION
This PR fixes #51 

## What has been added
 - RobotLogger now has a static `getPackageName(StackTraceElement element)` function that will generate a "friendly name" for any stack trace element
 - There is now a unit test to make sure this works correctly

## Example

What was originally 

```
io.github.frc5024.y2020.darthraider.commands.autonomous.actions.cells.SetShooterOutput::init()
```

Is now automatically shortened to

```
io...cells.SetShooterOutput::init()
```