### PR TITLE
Fix a path following bug

### DIFF
--- a/examples/PathWeaver/pathweaver.json
+++ b/examples/PathWeaver/pathweaver.json
@@ -1,8 +1,9 @@
 {
   "lengthUnit": "Meter",
+  "exportUnit": "Same as Project",
   "maxVelocity": 4.0,
   "maxAcceleration": 3.6,
   "wheelBase": 0.8,
-  "gameName": "FIRST Power Up",
+  "gameName": "Infinite Recharge",
   "outputDir": "../pw_outputs"
 }

--- a/purepursuit/src/main/java/io/github/frc5024/purepursuit/Follower.java
+++ b/purepursuit/src/main/java/io/github/frc5024/purepursuit/Follower.java
@@ -30,7 +30,7 @@ public class Follower {
      * 
      * @param path              Path to follow
      * @param lookaheadDistance Lookahead distance
-     * @param lookaheadGain     Lookahead gain
+     * @param lookaheadGain     The minimum distance required to fetch a new pose
      * @param drivebaseWidth    Drivebase width
      */
     public Follower(Path path, double lookaheadDistance, double lookaheadGain, double drivebaseWidth) {
@@ -112,6 +112,11 @@ public class Follower {
             // TODO: make this a FOR loop starting at m_lastLookaheadIndex
             while (true) {
 
+                // Keep using the current goal if we have not reached it
+                if (thisDist > m_lookaheadGain) {
+                    break;
+                }
+
                 // Attempt to incr our search index
                 nextIndex = ((nextIndex + 1) < m_path.getPoses().length) ? nextIndex + 1 : nextIndex;
 
@@ -150,7 +155,7 @@ public class Follower {
 
         // Set a Lookahead
         double L = 0.0;
-        double LF = m_lookaheadGain * v * m_lookaheadDist;
+        double LF = v * m_lookaheadDist;
 
         // Look for target
         int ind = m_lastLookaheadIndex;

--- a/purepursuit/src/test/java/io/github/frc5024/purepursuit/FollowerTest.java
+++ b/purepursuit/src/test/java/io/github/frc5024/purepursuit/FollowerTest.java
@@ -1,7 +1,10 @@
 package io.github.frc5024.purepursuit;
 
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
 
+import ca.retrylife.ewmath.MathUtils;
 import edu.wpi.first.wpilibj.geometry.Pose2d;
 import edu.wpi.first.wpilibj.geometry.Rotation2d;
 import edu.wpi.first.wpilibj.geometry.Translation2d;
@@ -12,6 +15,7 @@ public class FollowerTest {
 
     // Lookahead distance to test against
     double LOOKAHEAD = 0.2;
+    double GAIN = 0.1;
 
     @Test
     /**
@@ -22,18 +26,19 @@ public class FollowerTest {
 
         // Follower to test against
         Follower follower = new Follower(new Path(new Translation2d(0.0, 0.0), new Translation2d(1.0, 1.0)), LOOKAHEAD,
-                0.1, Units.inchesToMeters(28.0));
+                GAIN, Units.inchesToMeters(28.0));
 
         // Check for appropriate final pose
         assert follower.getFinalPose().equals(new Translation2d(1.0, 1.0));
 
         // Discard any pose inside the lookahead
         Translation2d goal = follower.getNextPoint(new Pose2d(0.0, 0.0, Rotation2d.fromDegrees(0.0)));
-        while (Math.hypot(goal.getX(), goal.getY()) < LOOKAHEAD) {
+        // while (Math.hypot(goal.getX(), goal.getY()) < LOOKAHEAD) {
 
-            // Grab a new goal
-            goal = follower.getNextPoint(new Pose2d(0.0, 0.0, Rotation2d.fromDegrees(0.0)));
-        }
+        // // Grab a new goal
+        // goal = follower.getNextPoint(new Pose2d(0.0, 0.0,
+        // Rotation2d.fromDegrees(0.0)));
+        // }
 
         // Check that the found point is forward, and to the right of the "chassis" when
         // sitting at (0,0)
@@ -55,18 +60,19 @@ public class FollowerTest {
 
         // Follower to test against
         Follower follower = new Follower(new Path(new Translation2d(0.0, 0.0), new Translation2d(-1.0, 1.0)), LOOKAHEAD,
-                0.1, Units.inchesToMeters(28.0));
+                GAIN, Units.inchesToMeters(28.0));
 
         // Check for appropriate final pose
         assert follower.getFinalPose().equals(new Translation2d(-1.0, 1.0));
 
         // Discard any pose inside the lookahead
         Translation2d goal = follower.getNextPoint(new Pose2d(0.0, 0.0, Rotation2d.fromDegrees(0.0)));
-        while (Math.hypot(goal.getX(), goal.getY()) < LOOKAHEAD) {
+        // while (Math.hypot(goal.getX(), goal.getY()) < LOOKAHEAD) {
 
-            // Grab a new goal
-            goal = follower.getNextPoint(new Pose2d(0.0, 0.0, Rotation2d.fromDegrees(0.0)));
-        }
+        // // Grab a new goal
+        // goal = follower.getNextPoint(new Pose2d(0.0, 0.0,
+        // Rotation2d.fromDegrees(0.0)));
+        // }
 
         // Check that the found point is forward, and to the right of the "chassis" when
         // sitting at (0,0)
@@ -77,5 +83,33 @@ public class FollowerTest {
         goal = follower.getNextPoint(new Pose2d(1.0, 0.0, Rotation2d.fromDegrees(0.0)));
         assert goal.getX() < 0.0;
         assert goal.getY() > 0.0;
+    }
+
+    @Test
+    public void testFollowerMaintainsProperSpacing() {
+
+        // Follower to test against
+        Follower follower = new Follower(new Path(new Translation2d(0.0, 0.0), new Translation2d(10.0, 10.0)),
+                LOOKAHEAD, GAIN, Units.inchesToMeters(28.0));
+
+        // Loop until we start seeing the same point multiple times
+        Translation2d lastPose = new Translation2d(-1, -1);
+        while (true) {
+
+            // Get the next pose
+            Translation2d nextPose = follower.getNextPoint(new Pose2d(0.0, 0.0, Rotation2d.fromDegrees(0.0)));
+
+            // Compare to the last
+            if (nextPose.equals(lastPose)) {
+                lastPose = nextPose;
+                break;
+            }
+
+            lastPose = nextPose;
+        }
+
+        // Check if the pose we got "stuck on" is near the lookahead gain
+        assertEquals("Farthest acceptable pose", true, MathUtils
+                .epsilonEquals(new Translation2d(0.0, 0.0).getDistance(lastPose), GAIN, Units.inchesToMeters(6.0)));
     }
 }


### PR DESCRIPTION
There was a bug where, when following a path, the goal pose would keep moving even if the robot wasn't. This means that, if the robot were moving too slow, it would completely skip some waypoints and just drive to the final waypoint.

I seem to have solved this, and added a new unit test to make sure the new follower output is reasonable