### PR TITLE
Add a safe Notifier wrapper

### DIFF
--- a/hardware/ni/build.gradle
+++ b/hardware/ni/build.gradle
@@ -1,6 +1,10 @@
 dependencies {
     // Logging
     implementation project(":logging")
+
+    // Utils
+    implementation project(":utils")
+
 }
 
 sourceSets {

--- a/hardware/ni/build.gradle
+++ b/hardware/ni/build.gradle
@@ -5,6 +5,9 @@ dependencies {
     // Utils
     implementation project(":utils")
 
+    // Apache commons Lang
+    implementation "org.apache.commons:commons-lang3:3.11"
+
 }
 
 sourceSets {

--- a/hardware/ni/src/main/java/io/github/frc5024/lib5k/hardware/ni/roborio/fpga/SafeNotifier.java
+++ b/hardware/ni/src/main/java/io/github/frc5024/lib5k/hardware/ni/roborio/fpga/SafeNotifier.java
@@ -17,6 +17,11 @@ public class SafeNotifier extends Notifier {
     // Logger
     // This must be static so we can access it from the wrapper
     private static RobotLogger logger = RobotLogger.getInstance();
+    private String name;
+
+    public SafeNotifier(String name, Runnable action) {
+        this(name, 0.20, action);
+    }
 
     public SafeNotifier(String name, double periodSeconds, Runnable action) {
 
@@ -28,9 +33,17 @@ public class SafeNotifier extends Notifier {
 
         // Name the notifier
         setName(name);
+        this.name = name;
 
         // Set the period
         this.period = periodSeconds;
+    }
+
+    protected Thread getUnderlyingThread() {
+        for (Thread t : Thread.getAllStackTraces().keySet()) {
+            if (t.getName().equals(this.name)) return t;
+        }
+        return null;
     }
 
     /**

--- a/hardware/ni/src/main/java/io/github/frc5024/lib5k/hardware/ni/roborio/fpga/SafeNotifier.java
+++ b/hardware/ni/src/main/java/io/github/frc5024/lib5k/hardware/ni/roborio/fpga/SafeNotifier.java
@@ -1,0 +1,90 @@
+package io.github.frc5024.lib5k.hardware.ni.roborio.fpga;
+
+import java.io.FileWriter;
+import java.io.IOException;
+
+import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.Notifier;
+import io.github.frc5024.lib5k.logging.RobotLogger;
+import io.github.frc5024.lib5k.logging.RobotLogger.Level;
+import io.github.frc5024.lib5k.utils.FileManagement;
+
+public class SafeNotifier extends Notifier {
+
+    // Custom period
+    private double period;
+
+    // Logger
+    // This must be static so we can access it from the wrapper
+    private static RobotLogger logger = RobotLogger.getInstance();
+
+    public SafeNotifier(String name, double periodSeconds, Runnable action) {
+
+        // Set up the notifier to run the action
+        super(() -> {
+            // Run the action with a wrapper around it
+            SafeNotifier.safetyWrapper(name, action);
+        });
+
+        // Name the notifier
+        setName(name);
+
+        // Set the period
+        this.period = periodSeconds;
+    }
+
+    /**
+     * Start the notifier with a pre-configured period. This will be 20ms by
+     * default, or whatever was passed into the constructor, or whatever was passed
+     * in to the last call to startPeriodic()
+     */
+    public void start() {
+        startPeriodic(this.period);
+    }
+
+    @Override
+    public void startPeriodic(double period) {
+        // Override the internal period
+        this.period = period;
+        super.startPeriodic(period);
+    }
+
+    private static void safetyWrapper(String name, Runnable action) {
+        // Wrap the runnable with an error handler
+        try {
+            action.run();
+        } catch (Throwable t) {
+            // Handle possible errors
+            String errorMessage = String.format("SafeNotifier for %s caught the following error: %s", name,
+                    t.getMessage());
+            logger.log(errorMessage, Level.kWarning);
+            DriverStation.reportError(errorMessage, t.getStackTrace());
+
+            // Attempt to write the error and stack trace to the session folder
+            double currentTime = FPGAClock.getFPGASeconds();
+
+            try {
+
+                // Get a session file
+                String fileName = String.format("SafeNotifier_%s_StackTrace_%d.txt", name, (int) currentTime);
+                FileWriter stackTraceWriter = FileManagement.createFileWriter(fileName);
+
+                // Write the stack trace
+                stackTraceWriter.append(String.format("Stack trace:%n"));
+                stackTraceWriter.append(t.getMessage() + "\n");
+                stackTraceWriter.append(t.getLocalizedMessage() + "\n");
+                stackTraceWriter.append(t.getStackTrace().toString());
+
+                // Inform the user what happened
+                logger.log(String.format("Saved stack trace in the current session folder as: %s", fileName));
+
+            } catch (IOException e) {
+                logger.log("Failed to save stack trace to the session directory", Level.kWarning);
+            }
+
+            // Re-throw the error
+            throw t;
+        }
+    }
+
+}

--- a/hardware/ni/src/test/java/io/github/frc5024/lib5k/hardware/ni/roborio/fpga/SafeNotifierTest.java
+++ b/hardware/ni/src/test/java/io/github/frc5024/lib5k/hardware/ni/roborio/fpga/SafeNotifierTest.java
@@ -1,8 +1,12 @@
 package io.github.frc5024.lib5k.hardware.ni.roborio.fpga;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
+
+import io.github.frc5024.lib5k.logging.RobotLogger;
 
 public class SafeNotifierTest {
 
@@ -10,21 +14,17 @@ public class SafeNotifierTest {
     public void testNotifierRethrowsException() {
         // Build a safe notifier
         SafeNotifier n = new SafeNotifier("RethrowTestNotifier", () -> {
+            RobotLogger.getInstance().log("Running test task");
+            RobotLogger.getInstance().flush();
             throw new RuntimeException("Test");
         });
 
-        // Do some low-level work to get the underlying thread of the notifier
-        Thread underlyingThread = n.getUnderlyingThread();
-
-        // Write a custom error handler
-        underlyingThread.setUncaughtExceptionHandler((thread, error) -> {
-            assertTrue(error instanceof RuntimeException);
-        });
-
         // Run the thread (This should throw an error)
-        n.startSingle(0.0);
-
+        Exception ex = assertThrows(RuntimeException.class, () -> n.getUnderlyingRunnable().run());
+        RobotLogger.getInstance().flush();
+        assertEquals("Test", ex.getMessage());
         
+
     }
 
 }

--- a/hardware/ni/src/test/java/io/github/frc5024/lib5k/hardware/ni/roborio/fpga/SafeNotifierTest.java
+++ b/hardware/ni/src/test/java/io/github/frc5024/lib5k/hardware/ni/roborio/fpga/SafeNotifierTest.java
@@ -1,0 +1,30 @@
+package io.github.frc5024.lib5k.hardware.ni.roborio.fpga;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class SafeNotifierTest {
+
+    @Test
+    public void testNotifierRethrowsException() {
+        // Build a safe notifier
+        SafeNotifier n = new SafeNotifier("RethrowTestNotifier", () -> {
+            throw new RuntimeException("Test");
+        });
+
+        // Do some low-level work to get the underlying thread of the notifier
+        Thread underlyingThread = n.getUnderlyingThread();
+
+        // Write a custom error handler
+        underlyingThread.setUncaughtExceptionHandler((thread, error) -> {
+            assertTrue(error instanceof RuntimeException);
+        });
+
+        // Run the thread (This should throw an error)
+        n.startSingle(0.0);
+
+        
+    }
+
+}


### PR DESCRIPTION
This PR completes issue #46 by implementing the new `SafeNotifier` class. This class:

 - Wraps the WPILib Notifier
 - Will reflect any exceptions to a file
 - Will log when something goes wrong

## Stack trace logging

For easier debugging, the `SafeNotifier` will save any stacktrace it encounters to the session directory. An example stack trace file (generated from a unit test) looks like this:

```
Stack trace:
Test
Test
java.lang.RuntimeException: Test
	at io.github.frc5024.lib5k.hardware.ni.roborio.fpga.SafeNotifierTest.lambda$testNotifierRethrowsException$0(SafeNotifierTest.java:19)
	at io.github.frc5024.lib5k.hardware.ni.roborio.fpga.SafeNotifier.safetyWrapper(SafeNotifier.java:116)
	at io.github.frc5024.lib5k.hardware.ni.roborio.fpga.SafeNotifier.lambda$new$1(SafeNotifier.java:57)
	at io.github.frc5024.lib5k.hardware.ni.roborio.fpga.SafeNotifierTest.lambda$testNotifierRethrowsException$1(SafeNotifierTest.java:23)
	at org.junit.Assert.assertThrows(Assert.java:1001)
	at org.junit.Assert.assertThrows(Assert.java:981)
	at io.github.frc5024.lib5k.hardware.ni.roborio.fpga.SafeNotifierTest.testNotifierRethrowsException(SafeNotifierTest.java:23)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.runTestClass(JUnitTestClassExecutor.java:110)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:58)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:38)
	at org.gradle.api.internal.tasks.testing.junit.AbstractJUnitTestClassProcessor.processTestClass(AbstractJUnitTestClassProcessor.java:62)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.processTestClass(SuiteTestClassProcessor.java:51)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:35)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:32)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:93)
	at com.sun.proxy.$Proxy2.processTestClass(Unknown Source)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.processTestClass(TestWorker.java:118)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:35)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:175)
	at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:157)
	at org.gradle.internal.remote.internal.hub.MessageHub$Handler.run(MessageHub.java:404)
	at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:63)
	at org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:46)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at org.gradle.internal.concurrent.ThreadFactoryImpl$ManagedThreadRunnable.run(ThreadFactoryImpl.java:55)
	at java.base/java.lang.Thread.run(Thread.java:834)

```

## Unit tests

I have added a new unit test that purposely throws a RuntimeException. Don't be alarmed when you see a stack trace get dumped to you screen when running unit tests. As long as the test passes, all is good.