### PR TITLE
Expose RobotProgram's internal dashboard

### DIFF
--- a/lib5k/src/main/java/io/github/frc5024/lib5k/autonomous/RobotProgram.java
+++ b/lib5k/src/main/java/io/github/frc5024/lib5k/autonomous/RobotProgram.java
@@ -6,7 +6,6 @@ import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
-import edu.wpi.first.wpilibj2.command.CommandBase;
 
 import io.github.frc5024.lib5k.logging.RobotLogger;
 import io.github.frc5024.lib5k.hardware.ni.roborio.FaultReporter;
@@ -87,6 +86,14 @@ public abstract class RobotProgram extends TimedRobot {
      */
     public void publishChooser(Sendable component) {
         dashboard.add(component);
+    }
+
+    /**
+     * Get a reference to the ShuffleboardTab used by this program
+     * @return Internal ShuffleboardTab
+     */
+    public ShuffleboardTab getDashboardTab() {
+        return dashboard;
     }
 
     /**


### PR DESCRIPTION
This adds a new method `RobotProgram.getDashboardTab()`, which just returns whatever dashboard tab the RobotProgram object has been configured to use.